### PR TITLE
user_id and screen_name are optional for now

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -716,8 +716,8 @@ returned in the current_status field.
 
 | Name | Required | type |
 | ---- | -------- | ---- |
-| user_id | true | number |
-| screen_name | true | string |
+| user_id | false | number |
+| screen_name | false | string |
 | include_entities | false | boolean |
   
 #### Link

--- a/src/spec/twitter-api-spec.yml
+++ b/src/spec/twitter-api-spec.yml
@@ -1298,13 +1298,13 @@
               description: |
                 The ID of the user for whom to return results. Either an id or
                 screen_name is required for this method.
-              required: true
+              required: false
               type: number
             - name: screen_name
               description: |
                 The screen name of the user for whom to return results. Either
                 a id or screen_name is required for this method.
-              required: true
+              required: false
               type: string
             - name: include_entities
               description: The entities node will not be included when set to false.


### PR DESCRIPTION
Solves #11 

`user_id` and `screen_name` are optional until we implement a better solution in the future.